### PR TITLE
Import decks and cards via remote JSON

### DIFF
--- a/lib/ImportFromURL.dart
+++ b/lib/ImportFromURL.dart
@@ -1,0 +1,134 @@
+import "./database.dart";
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import 'dart:convert';
+
+import './models/FlashCard.dart';
+import './models/Deck.dart';
+
+Future<List<Deck>> getDeckList() async {
+  List<Deck> deckList = await DBProvider.db.getAllDecks();
+  return deckList;
+}
+
+// Create a Form Widget
+class MyCustomForm extends StatefulWidget {
+  @override
+  MyCustomFormState createState() {
+    return MyCustomFormState();
+  }
+}
+
+// Create a corresponding State class. This class will hold the data related to
+// the form.
+class MyCustomFormState extends State<MyCustomForm> {
+  // Create a global key that will uniquely identify the Form widget and allow
+  // us to validate the form
+  //
+  // Note: This is a GlobalKey<FormState>, not a GlobalKey<MyCustomFormState>!
+  final _formKey = GlobalKey<FormState>();
+  Map<String, String> _urlForm = {
+    "url": "",
+  };
+
+  @override
+  initState() {
+    super.initState();
+  }
+
+  Future<void> addCardToDeckId(FlashCard card, int deckId) async {
+    int cardId = await DBProvider.db.insertFlashCard(card);
+    await DBProvider.db
+        .insertDeckToFlashCardById(deckId: deckId, cardId: cardId);
+  }
+
+  Future<int> buildDeckFromImport(parsed) async {
+    Deck newDeck = new Deck(title: parsed["title"]);
+    int newDeckId = await DBProvider.db.insertDeck(newDeck);
+    var futures = <Future>[];
+    parsed["cards"].forEach((card) {
+      FlashCard thisCard = new FlashCard.fromMap(card);
+      futures.add(addCardToDeckId(thisCard, newDeckId));
+    });
+    await Future.wait(futures);
+    return newDeckId;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Build a Form widget using the _formKey we created above
+    return Form(
+      key: _formKey,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          TextFormField(
+              minLines: 1,
+              maxLines: 2,
+              decoration: InputDecoration(
+                alignLabelWithHint: true,
+                labelText: "URL",
+                labelStyle: TextStyle(fontSize: 20),
+              ),
+              validator: (value) {
+                if (value.isEmpty) {
+                  return 'Please enter a valid URL for import';
+                }
+                return null;
+              },
+              onSaved: (String value) {
+                this._urlForm["url"] = value;
+              }),
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 16.0),
+            child: RaisedButton(
+              onPressed: () async {
+                if (_formKey.currentState.validate()) {
+                  _formKey.currentState.save();
+                  var response = await http.get(this._urlForm["url"]);
+                  var parsed = json.decode(response.body);
+                  int newDeckId = await buildDeckFromImport(parsed);
+                  Navigator.pop(context, {
+                    "deckId": newDeckId,
+                  });
+                }
+              },
+              child: Text("IMPORT"),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class ImportFromURL extends StatelessWidget {
+  static const routeName = "/importFromURL";
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: Text('Add A Card'),
+        ),
+        body: SafeArea(
+            child: Center(
+                child: FractionallySizedBox(
+                    widthFactor: 0.8,
+                    heightFactor: 0.8,
+                    child: Card(
+                        child: Column(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            children: [
+                          new Expanded(
+                              flex: 1,
+                              child: Center(
+                                  child: SingleChildScrollView(
+                                padding: EdgeInsets.all(24.0),
+                                child: MyCustomForm(),
+                              )))
+                        ]))))));
+  }
+}

--- a/lib/database.dart
+++ b/lib/database.dart
@@ -60,7 +60,7 @@ class DBProvider {
     return res.isNotEmpty ? FlashCard.fromMap(res.first) : null;
   }
 
-  Future<Deck> getDeck({String deckId}) async {
+  Future<Deck> getDeck({int deckId}) async {
     final db = await database;
     var res = await db.query("Deck", where: "id = ?", whereArgs: [deckId]);
     return res.isNotEmpty ? Deck.fromMap(res.first) : null;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -46,6 +46,20 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.12.0+2"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.3"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
     sdk: flutter
   sqflite: ^1.1.5
   path_provider: ^0.4.1
+  http: ^0.12.0+2
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
This PR allows you to enter a URL on the "Import from URL" screen and enter the URL of a JSON file containing a deck with cards. The deck is automatically created, along with all of the cards, and it takes you to the deck screen directly.

The most likely use case for this (for now) is:

1. Create a JSON flashcards file and save it as a public GitHub gist.
```json
{
  "title": "deckTitle",
  "cards": [
    {
      "title": "t0",
      "front": "front0",
      "back": "back0"
    },
    {
      "title": "t1",
      "front": "front1",
      "back": "back1"
    },
    {
      "title": "t2",
      "front": "front2",
      "back": "back2"
    },
    {
      "title": "t3",
      "front": "front3",
      "back": "back3"
    }
  ]
}
```

2. Upload it as a RAW public Github Git (e.g. https://gist.githubusercontent.com/thmsdnnr/c6c7b4d58ce61de769d1a83dc835ac2d/raw/758896e4f63e2be5ea79909cb8a5cad120a4a9d3/deckofcards.json)
3. Go to https://git.io & enter your RAW content in the shortener (e.g. https://git.io/fjgk4)
<img width="240" alt="Screen Shot 2019-06-09 at 9 21 28 PM" src="https://user-images.githubusercontent.com/18345212/59172396-97855480-8afc-11e9-9880-6b92917142c5.png">

4. Huzzah 😸 
<img width="240" alt="Screen Shot 2019-06-09 at 9 21 36 PM" src="https://user-images.githubusercontent.com/18345212/59172395-97855480-8afc-11e9-8a84-dce3d0154a46.png">
