### PR TITLE
Add swipeability, add card grading, add SuperMemo 2 algorithm

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,7 +49,6 @@ class _MyHomePageState extends State<MyHomePage> {
   int _totalCardCt = 0;
   int _cardGrade = -1;
   Deck _chosenDeck;
-  Card _chosenCard;
   PageController controller;
 
   static final FlashCardSide BackSideOfCard = FlashCardSide.back;
@@ -58,24 +57,6 @@ class _MyHomePageState extends State<MyHomePage> {
   initState() {
     super.initState();
     grabCardsAndDisplay();
-  }
-
-  Future<void> buildFakeData() async {
-    Deck newDeck = new Deck(id: 6, title: "A sick deck");
-    Deck newDeck2 = new Deck(id: 4, title: "A sick deck");
-    await DBProvider.db.insertDeck(newDeck);
-    await DBProvider.db.insertDeck(newDeck2);
-    var futures = <Future>[];
-    new List<int>.generate(10, (i) {
-      FlashCard thisCard = new FlashCard(
-          id: i, title: "test card $i", front: "$i front", back: "$i back");
-      futures.add(DBProvider.db.insertFlashCard(thisCard));
-      futures.add(
-          DBProvider.db.insertDeckToFlashCard(deck: newDeck, card: thisCard));
-      futures.add(
-          DBProvider.db.insertDeckToFlashCard(deck: newDeck, card: thisCard));
-    });
-    await Future.wait(futures);
   }
 
   void grabCardsAndDisplay({int deckId, DeckPosition startAt}) async {
@@ -100,29 +81,6 @@ class _MyHomePageState extends State<MyHomePage> {
       } else {
         _shownSide = FlashCardSide.front;
       }
-    });
-  }
-
-  bool _canGoBack() => _activeCardIdx > 0 ? true : false;
-  bool _canGoForward() => _activeCardIdx == _totalCardCt - 1 ? false : true;
-
-  void _handleBackPress() {
-    if (!_canGoBack()) {
-      return;
-    }
-    setState(() {
-      _activeCardIdx = _activeCardIdx - 1;
-      _shownSide = FlashCardSide.front;
-    });
-  }
-
-  void _handleForwardPress() {
-    if (!_canGoForward()) {
-      return;
-    }
-    setState(() {
-      _activeCardIdx = _activeCardIdx + 1;
-      _shownSide = FlashCardSide.front;
     });
   }
 
@@ -251,32 +209,6 @@ class _MyHomePageState extends State<MyHomePage> {
       setState(() {
         grabCardsAndDisplay(deckId: createdDeckId["deckId"]);
       });
-    }
-  }
-
-  Widget buildCardNavigation() {
-    if (_cardList != null &&
-        _activeCardIdx >= 0 &&
-        _activeCardIdx < _cardList.length) {
-      return ButtonBar(
-        mainAxisSize: MainAxisSize.min,
-        alignment: MainAxisAlignment.center,
-        children: <Widget>[
-          new IconButton(
-            icon: new Icon(Icons.arrow_back, size: 32),
-            onPressed: _canGoBack() == true ? _handleBackPress : null,
-          ),
-          Text("${_activeCardIdx + 1} / $_totalCardCt",
-              style: TextStyle(fontWeight: FontWeight.w500, fontSize: 24),
-              textAlign: TextAlign.center),
-          new IconButton(
-            icon: new Icon(Icons.arrow_forward, size: 32),
-            onPressed: _canGoForward() == true ? _handleForwardPress : null,
-          ),
-        ],
-      );
-    } else {
-      return null;
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -157,10 +157,12 @@ class _MyHomePageState extends State<MyHomePage> {
     // grab the deck the users selects when the page returns
     dynamic selectedDeck =
         await Navigator.of(context).pushNamed(DeckSelector.routeName);
-    setState(() {
-      _chosenDeck = selectedDeck;
-      grabCardsAndDisplay(deckId: _chosenDeck.id);
-    });
+    if (selectedDeck != null && selectedDeck.id != null) {
+      setState(() {
+        _chosenDeck = selectedDeck;
+        grabCardsAndDisplay(deckId: _chosenDeck.id);
+      });
+    }
   }
 
   Future createACard(BuildContext context) async {
@@ -178,10 +180,9 @@ class _MyHomePageState extends State<MyHomePage> {
   Future importFromURL(BuildContext context) async {
     dynamic createdDeckId =
         await Navigator.of(context).pushNamed(ImportFromURL.routeName);
-    int theId = createdDeckId["deckId"];
-    if (theId != null) {
+    if (createdDeckId != null && createdDeckId["deckId"] != null) {
       setState(() {
-        grabCardsAndDisplay(deckId: theId);
+        grabCardsAndDisplay(deckId: createdDeckId["deckId"]);
       });
     }
   }

--- a/lib/models/FlashCard.dart
+++ b/lib/models/FlashCard.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/material.dart';
-
 enum FlashCardSide { front, back }
 
 class FlashCard {

--- a/lib/models/FlashCard.dart
+++ b/lib/models/FlashCard.dart
@@ -27,30 +27,4 @@ class FlashCard {
         "front": front,
         "back": back,
       };
-
-  FractionallySizedBox toWidget({FlashCardSide sideToDisplay}) =>
-      FractionallySizedBox(
-        widthFactor: 0.9,
-        heightFactor: 0.9,
-        child: Card(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              new Expanded(
-                  flex: 1,
-                  child: Center(
-                    child: SingleChildScrollView(
-                        padding: EdgeInsets.all(24.0),
-                        child: Text(
-                          sideToDisplay == FlashCardSide.front ? front : back,
-                          style: TextStyle(
-                              fontWeight: FontWeight.w500, fontSize: 32),
-                          textAlign: TextAlign.center,
-                        )),
-                  ))
-            ],
-          ),
-        ),
-      );
 }

--- a/lib/models/FlashCard.dart
+++ b/lib/models/FlashCard.dart
@@ -30,8 +30,8 @@ class FlashCard {
 
   FractionallySizedBox toWidget({FlashCardSide sideToDisplay}) =>
       FractionallySizedBox(
-        widthFactor: 0.8,
-        heightFactor: 0.8,
+        widthFactor: 0.9,
+        heightFactor: 0.9,
         child: Card(
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/models/Grade.dart
+++ b/lib/models/Grade.dart
@@ -1,0 +1,69 @@
+import "dart:math";
+
+class Grade {
+  Grade(
+      {this.id,
+      this.flashCardId,
+      this.reps = 0,
+      this.easiness = 2.5,
+      this.interval = 1,
+      this.nextPracticeTimestamp});
+
+  int id;
+  int flashCardId;
+  int reps;
+  double easiness;
+  int interval;
+  int nextPracticeTimestamp;
+
+  String toString() {
+    return "$id $flashCardId $reps $easiness $interval $nextPracticeTimestamp";
+  }
+
+  Grade updateGradeWithQuality(int quality) {
+    int newReps = this.reps + 1;
+    if (quality < 3) {
+      newReps = 0;
+    }
+    double newEasiness = max(1.3,
+        easiness + 0.1 - (5.0 - quality) * (0.08 + (5.0 - quality) * 0.02));
+    int newInterval = 0;
+    if (newReps < 2) {
+      newInterval = 1;
+    } else if (newReps == 2) {
+      newInterval = 6;
+    } else {
+      newInterval = (newInterval * newEasiness).round();
+    }
+    DateTime rightNow = DateTime.now().add(Duration(days: interval));
+    int newNextPracticeTimestamp = rightNow.millisecondsSinceEpoch;
+    return new Grade.fromMap({
+      "id": this.id,
+      "flashCardId": this.flashCardId,
+      "reps": newReps,
+      "easiness": newEasiness,
+      "interval": newInterval,
+      "nextPracticeTimestamp": newNextPracticeTimestamp,
+    });
+  }
+
+  factory Grade.fromMap(Map<String, dynamic> json) => new Grade(
+        id: json["id"],
+        flashCardId: json["flashCardId"],
+        reps: json["reps"],
+        easiness: json["easiness"],
+        interval: json["interval"],
+        nextPracticeTimestamp: json["nextPracticeTimestamp"],
+      );
+
+  Map<String, dynamic> toMap() {
+    return {
+      "id": id,
+      "flashCardId": flashCardId,
+      "reps": reps,
+      "easiness": easiness,
+      "interval": interval,
+      "nextPracticeTimestamp": nextPracticeTimestamp
+    };
+  }
+}


### PR DESCRIPTION
You can now swipe left / right up / down depending on screen mode to advance cards and flip the cards with a tap. When you view the back side of a card, a "grading" system will come up:

<img width="600" alt="Screen Shot 2019-06-10 at 10 02 18 PM" src="https://user-images.githubusercontent.com/18345212/59244939-7475a600-8bcb-11e9-9855-0569b78dcae9.png">
<img width="600" alt="Screen Shot 2019-06-10 at 10 02 11 PM" src="https://user-images.githubusercontent.com/18345212/59244940-7475a600-8bcb-11e9-8094-f4fac29f9dcd.png">

>REMEMBERING
Bright (press 5), excellent response
Good (press 4), correct response provided with some hesitation
Pass (press 3), answer recalled with difficulty; perhaps, slightly incorrect

> FORGETTING
Fail (press 2), wrong response that makes you say I knew it!
Bad (press 1), wrong response; the correct answer seems to be familiar
Null (press 0), complete blackout; you do not even recall ever knowing the answer

—from [supermemo.com grades explanation](https://www.supermemo.com/help/learn.htm#Grades)

The grades 0 - 5 correspond to the SuperMemo grades of recall for a card. SuperMemo2 was implemented with help from [https://stackoverflow.com/a/49047160/7316502](https://stackoverflow.com/a/49047160/7316502). If no grade is selected, nothing is recorded. Default grades are set for each card.

The gist is that when one records a grade as to the recall of a card, we can use that information to calculate a `nextPracticeTimestamp`, and a deck can be formed dynamically from the list of all cards such that `nextPracticeTimestamp <= timestamp.now()`